### PR TITLE
[Bugfix] Fix pen tool blocking non-annotation mouse down actions

### DIFF
--- a/src/UI/pen.js
+++ b/src/UI/pen.js
@@ -22,10 +22,10 @@ let lines = [];
 function handleDocumentPointerdown(e) {
   path = null;
   lines = [];
-  _candraw = true;
-  /* if (!e.srcElement.classList.contains('annotationLayer')) {
+  if (!findSVGAtPoint(e.clientX, e.clientY)) {
     return;
-  } */
+  }
+  _candraw = true;
   e.preventDefault();
 }
 
@@ -39,6 +39,9 @@ function handleDocumentPointerup(e) {
 }
 
 function saveToStorage(x, y) {
+  if (!_candraw) {
+    return;
+  }
   _candraw = false;
   let svg;
   if (lines.length > 1 && (svg = findSVGAtPoint(x, y))) {
@@ -64,12 +67,10 @@ function saveToStorage(x, y) {
  * @param {PointerEvent} e The DOM event to be handled
  */
 function handleDocumentPointermove(e) {
-  if (!e.srcElement.classList.contains('annotationLayer')) {
+  if (!findSVGAtPoint(e.clientX, e.clientY) || !_candraw) {
     return;
   }
-  if (_candraw) {
-    savePoint(e.clientX, e.clientY);
-  }
+  savePoint(e.clientX, e.clientY);
 }
 
 /**

--- a/test/UI/pen.spec.js
+++ b/test/UI/pen.spec.js
@@ -1,4 +1,4 @@
-import { equal, deepStrictEqual } from 'assert';
+import { deepStrictEqual, strictEqual } from 'assert';
 import PDFJSAnnotate from '../../src/PDFJSAnnotate';
 import { firePointerEvent } from '../fireEvent';
 import mockAddAnnotation from '../mockAddAnnotation';
@@ -69,7 +69,7 @@ describe('UI::pen', function() {
     disablePen();
     simulateCreateDrawingAnnotation();
     setTimeout(function() {
-      equal(addAnnotationSpy.called, false);
+      strictEqual(addAnnotationSpy.called, false);
       done();
     }, 0);
   });
@@ -79,14 +79,49 @@ describe('UI::pen', function() {
     enablePen();
     simulateCreateDrawingAnnotation();
     setTimeout(function() {
-      equal(addAnnotationSpy.called, true);
-      let args = addAnnotationSpy.getCall(0).args;
-      equal(args[0], 'test-document-id');
-      equal(args[1], '1');
-      equal(args[2].type, 'drawing');
-      equal(args[2].width, 1);
-      equal(args[2].color, '000000');
-      equal(args[2].lines.length, 2);
+      strictEqual(addAnnotationSpy.called, true);
+      const args = addAnnotationSpy.getCall(0).args;
+      strictEqual(args[0], 'test-document-id');
+      strictEqual(args[1], 1);
+      strictEqual(args[2].type, 'drawing');
+      strictEqual(args[2].width, 1);
+      strictEqual(args[2].color, '000000');
+      strictEqual(args[2].lines.length, 2);
+      done();
+    }, 0);
+  });
+
+  it('should not create annotation if started outside annotation layer', (done) => {
+    disablePen();
+    enablePen();
+    setPen();
+
+    firePointerEvent(svg, 'pointerdown', {
+      clientX: 2000,
+      clientY: 10,
+      pointerType: 'mouse'
+    });
+
+    firePointerEvent(svg, 'pointermove', {
+      clientX: 15,
+      clientY: 15,
+      pointerType: 'mouse'
+    });
+
+    firePointerEvent(svg, 'pointermove', {
+      clientX: 30,
+      clientY: 30,
+      pointerType: 'mouse'
+    });
+
+    firePointerEvent(svg, 'pointerup', {
+      clientX: 30,
+      clientY: 30,
+      pointerType: 'mouse'
+    });
+
+    setTimeout(() => {
+      strictEqual(addAnnotationSpy.called, false);
       done();
     }, 0);
   });


### PR DESCRIPTION
Fixes Submitty/Submitty#4599. If the pen tool is selected, it was blocking regular mouse down actions from occurring that were unrelated to annotations, most easily noticeable in that it would block the size dropdowns.