### PR TITLE
Semantic versioning enforced

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@submitty/pdf-annotate.js",
-  "version": "v24.06.01",
+  "version": "24.06.02",
   "description": "Annotation layer for pdf.js",
   "main": "index.js",
   "types": "types",


### PR DESCRIPTION
NPM enforces semantic versioning, so match the format of the last working version (2.5.1) by removing the "v" from tags / version names.